### PR TITLE
Fix notion-cli CI test failures from Notion API rate limiting

### DIFF
--- a/.github/workflows/notion-cli.yml
+++ b/.github/workflows/notion-cli.yml
@@ -2,12 +2,17 @@ name: notion-cli
 
 on:
   push:
+    branches: [main]
     paths:
       - "notion-cli/**"
   pull_request:
     paths:
       - "notion-cli/**"
   workflow_dispatch: # allow manual runs
+
+concurrency:
+  group: notion-cli-${{ github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:

--- a/notion-cli/package.json
+++ b/notion-cli/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "prepare": "npm run build",
     "cli": "npx tsx cli.ts",
-    "test": "node --import tsx --test ./test/docs.test.ts ./test/user.test.ts ./test/search.test.ts ./test/page.test.ts ./test/block.test.ts ./test/comment.test.ts ./test/database.test.ts ./test/datasource.test.ts ./test/file.test.ts ./test/integration-cmd.test.ts",
+    "test": "node --import tsx --test --test-concurrency=1 ./test/docs.test.ts ./test/user.test.ts ./test/search.test.ts ./test/page.test.ts ./test/block.test.ts ./test/comment.test.ts ./test/database.test.ts ./test/datasource.test.ts ./test/file.test.ts ./test/integration-cmd.test.ts",
     "test:docs": "node --import tsx --test ./test/docs.test.ts",
     "test:user": "node --import tsx --test ./test/user.test.ts",
     "test:search": "node --import tsx --test ./test/search.test.ts",


### PR DESCRIPTION
Run test files sequentially (--test-concurrency=1) to avoid overwhelming Notion's rate limit when all 10 files hit the API in parallel.